### PR TITLE
Enable GeoDjango support in settings and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
       with:
         python-version: '3.10'
 
+    - name: Install GDAL dependencies for GeoDjango
+      run: |
+          sudo apt-get update
+          sudo apt-get install -y binutils libproj-dev gdal-bin libgdal-dev
+
     - name: Install uv
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
- Added `django.contrib.gis` to` INSTALLED_APPS `in `settings.py`
- Configured PostGIS engine in `settings.py`
- Installed GDAL and PostGIS system dependencies in CI Configuration

ref: https://docs.djangoproject.com/en/5.2/ref/contrib/gis/install/