### PR TITLE
Add address error popups

### DIFF
--- a/static/js/address_submission.js
+++ b/static/js/address_submission.js
@@ -10,6 +10,12 @@ async function getApartment() {
   // Need this inside getApartment since we need this on submit
   const address = document.getElementById('addressInput').value.trim();
 
+  // Clear notifications before starting
+  hideNotification("hydeParkWarning");
+  hideNotification("noMatchError");
+  hideNotification("serverError");
+
+
   // Data validation
   if (!address) {
     alert('Please enter an address.');
@@ -19,14 +25,29 @@ async function getApartment() {
   try {
     const response = await sendRequest(address);
 
-    // Placeholder for DOM modification
-    hideRentSmarterBox()
+    // After receiving the response, handle different error and show popups
+    if (!response.ok) {
+      const data = await response.json();
+    
+      if (data.Error.includes("Address is not inside the area")) {
+        showNotification("hydeParkWarning");
+      } else if (data.Error.includes("No matched address")) {
+        showNotification("noMatchError");
+      } else if (data.Error.includes("Censusgeocode service error")) {
+        showNotification("serverError");
+      } else {
+        alert(data.Error); 
+      }
+      return;
+    }
 
     // Check response 
-    if (!response.ok) throw new Error(`Server responded with status ${response.status}`);
+    // if (!response.ok) throw new Error(`Server responded with status ${response.status}`);
 
     // Parse data and place on map, assuming appropriate format from endpoint
     const data = await response.json();
+    // Placeholder for DOM modification
+    hideRentSmarterBox()
     placeAddress(data);
   } catch (err) {
     console.error('Address request could not be resolved by Server:', err.message);

--- a/static/js/error_popups.js
+++ b/static/js/error_popups.js
@@ -1,0 +1,13 @@
+function showNotification(id) {
+    const allIds = ['hydeParkWarning', 'noMatchError', 'serverError'];
+    allIds.forEach(hideNotification);
+  
+    const el = document.getElementById(id);
+    if (el) el.classList.remove('is-hidden');
+  }
+  
+  function hideNotification(id) {
+    const el = document.getElementById(id);
+    if (el) el.classList.add('is-hidden');
+  }
+  

--- a/templates/home.html
+++ b/templates/home.html
@@ -36,6 +36,23 @@
             </button>
           </div>
         </div>
+        
+
+        <!-- Error popups -->
+        <div id="hydeParkWarning" class="notification is-warning is-light is-hidden">
+          <button class="delete" onclick="hideNotification('hydeParkWarning')"></button>
+          The address is outside the Hyde Park area. Please try another location within the project boundaries.
+        </div>
+
+        <div id="noMatchError" class="notification is-danger is-light is-hidden">
+          <button class="delete" onclick="hideNotification('noMatchError')"></button>
+          We couldn’t find a match for that address. Please check the spelling or try a different one.
+        </div>
+
+        <div id="serverError" class="notification is-danger is-light is-hidden">
+          <button class="delete" onclick="hideNotification('serverError')"></button>
+          The address matching service is temporarily unavailable. Please try again later.
+        </div>
 
         <!-- Bullets -->
         <div class="mt-5">
@@ -270,6 +287,7 @@
   to-do: refactor to combine both of thes script blocks with the DOM updates
   Referenced by //Attach search event listener script, so must be first
 -->
+<script src="{% static 'js/error_popups.js' %}"></script>
 <script src="{% static 'js/address_submission.js' %}"></script>
 <script>
   // Attach search event listener


### PR DESCRIPTION
Hi @m-rosenbaum ! I added the logic for displaying error popups when the address is invalid, outside Hyde Park, or if the geocoding service fails. The popups work correctly on the initial search box.

However, I haven’t yet figured out how to re-insert those popups inside the innerHTML replacement when the Rent Smarter box is hidden. I’m wondering whether it’s worth keeping that function as is or if there's a better way to structure it. Happy to get input or suggestions on how to handle that part, maybe James has some ideas too?

Thanks!

