### PR TITLE
add better exception handling for fetch_inspections with all tests passed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Created by https://www.toptal.com/developers/gitignore/api/python,osx,django,jupyternotebooks
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,osx,django,jupyternotebooks
 
-data/
+/data/
 .idea/
 
 ### Django ###

--- a/apt_app/views/fetch_inspections.py
+++ b/apt_app/views/fetch_inspections.py
@@ -1,36 +1,86 @@
 from apt_app.models import Violation, InspectionSummary
 import datetime
 from django.http import JsonResponse, HttpRequest
+import logging
+
+# Get a logger for this module
+logger = logging.getLogger(__name__)
 
 
 def parse_address(in_address):
-    """get the part of address that is before "Chicago IL 60XXX"""
+    """get the first part of address, before "Chicago IL 60XXX"""
     return in_address.split(",")[0].strip()
 
 
-def _fetch_inspection_summaries(address) -> JsonResponse:
-    # TODO: need to add more error handling, but currently blocked by updating the backend data
+def _fetch_inspection_summaries(address, start_date=datetime.date(2020, 1, 1)) -> JsonResponse:
+    """
+    Fetch inspection summaries for a given address and cut-off date.
+
+    Args:
+        address (str): The address to fetch inspection summaries for.
+        start_date (datetime.date): The cut-off date to count the number of inspections and \
+            violations. Currently hardcoded to the default of 2020-01-01 for recency.
+
+    ref:
+    - https://docs.djangoproject.com/en/5.1/ref/models/class/#doesnotexist
+    """
+
+    # TODO: refine error handling
     try:
+        if not address:
+            return JsonResponse({"error": "Address is required"}, status=400)
+
         parsed_address = parse_address(address)
-        cut_off_date = datetime.date(2020, 1, 1)
+        if not parsed_address:
+            return JsonResponse({"error": "Invalid address format"}, status=400)
+
+        logger.info(f"Fetching violations for address: {parsed_address}")
+
+        content = {"address": parsed_address, "start_date": start_date}
 
         violations = (
             Violation.objects.filter(address__istartswith=parsed_address)
-            .filter(violation_date__gt=cut_off_date)
+            .filter(violation_date__gt=start_date)
+            # TODO: need to probably remove or relax this filter -- to be not just complaint
             .filter(inspection_category="COMPLAINT")
         )
 
         total_violations_count = violations.count()
         total_inspections_count = violations.distinct("inspection_number").count()
+        logger.info(
+            f"Total violations: {total_violations_count}"
+            f"Total inspections: {total_inspections_count}"
+        )
+
+        # first case: no violations found
+        if total_violations_count == 0:
+            content["data_status"] = "no_violations"
+            content["note"] = "no violation record found for this address"
+            return JsonResponse(content, status=200)
+
+        content["total_violations_count"] = total_violations_count
+        content["total_inspections_count"] = total_inspections_count
 
         inspection_summary = InspectionSummary.objects.filter(
             address__istartswith=parsed_address
-        ).first()
-
+        ).first()  # TODO: need to use time-based sorting later
         summary_json = inspection_summary.summary
-        summary_json["total_violations_count"] = total_violations_count
-        summary_json["total_inspections_count"] = total_inspections_count
-        summary_json["cut_off_date"] = cut_off_date
-        return JsonResponse(summary_json, status=200)
+        logger.debug(f"Inspection summary JSON: {summary_json}")
+
+        # second case: violations found but considered trivial and thus not summarized
+        if not summary_json:
+            content["data_status"] = "trivial_only"
+            content["note"] = (
+                f"{total_violations_count} trivial violations were recorded on "
+                f"{total_inspections_count} occasions and omitted here for brevity."
+            )
+            return JsonResponse(content, status=200)
+
+        # third case: violations found and summarized
+        content = content | summary_json
+        content["data_status"] = "available"
+        return JsonResponse(content, status=200)
+
     except Exception as e:
+        logger.error(f"An error occurred: {str(e)}")
         return JsonResponse({"error": str(e)}, status=500)

--- a/config/settings.py
+++ b/config/settings.py
@@ -39,7 +39,10 @@ else:
     SECRET_KEY = env.str("SECRET_KEY")
     _DEFAULT_DB = env.db()
     EMAIL_CONFIG = env.email()
-_DEFAULT_DB["ENGINE"] = "django.contrib.gis.db.backends.postgis" # Added engine for PostGIS
+_DEFAULT_DB["ENGINE"] = "django.contrib.gis.db.backends.postgis"  # Added engine for PostGIS
+# ref: https://stackoverflow.com/a/79522985
+_DEFAULT_DB["TEST"] = {"MIRROR": "default"}
+
 DATABASES = {"default": _DEFAULT_DB}
 vars().update(EMAIL_CONFIG)
 
@@ -64,7 +67,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
-    "django.contrib.gis", # Added for GeoDjango
+    "django.contrib.gis",  # Added for GeoDjango
     "allauth",
     "allauth.account",
     # Uncomment for MFA/Webauthn
@@ -241,10 +244,10 @@ LOGGING = {
         # Modify this to match the name of your application.
         # to configure different logging for your app vs. Django's
         # internals.
-        # "YOUR_APP": {
-        #    "handlers": ["console", "flat_line_file", "json_file"],
-        #    "level": "INFO",
-        # },
+        "apt_app": {
+            "handlers": ["console", "flat_line_file", "json_file"],
+            "level": "INFO",
+        },
     },
 }
 

--- a/tests/data/fetch_inspections_return.json
+++ b/tests/data/fetch_inspections_return.json
@@ -1,0 +1,48 @@
+[{
+    "data_status": "available",
+    "address": "5514 S BLACKSTONE AVE",
+    "summary": "This building has received complaints about heating issues, hot water problems, and maintenance concerns in the past 5 years.",
+    "note": "Unauthorized uses and cases where inspectors were denied entry were omitted.",
+    "total_violations_count": 12,
+    "total_inspections_count": 2,
+    "start_date": "2020-01-01",
+    "summarized_issues": [
+        {
+            "date": "Jan 2024",
+            "issues": [
+                {
+                    "emoji": "\ud83c\udf21\ufe0f",
+                    "description": "Inadequate heating and drafty windows with air seepage in Units 102, 103, and 104"
+                },
+                {
+                    "emoji": "\ud83d\udebf",
+                    "description": "Hot water issues with low temperature (45-59\u00b0F) and low pressure in Units 102, 103, 104, and 205"
+                }
+            ]
+        },
+        {
+            "date": "Oct 2023",
+            "issues": [
+                {
+                    "emoji": "\ud83d\uddd1\ufe0f",
+                    "description": "Overfilled trash cans and bags on the ground at west elevation"
+                }
+            ]
+          }
+      ]
+  },
+  {
+    "data_status": "trivial_only",
+    "address": "1451 E 55TH ST",
+    "note": "6 trivial violations were recorded on 2 occasions and omitted from the summary.",
+    "total_violations_count": 2,
+    "total_inspections_count": 6,
+    "start_date": "2020-01-01"
+  },
+  {
+    "data_status": "no_violations",
+    "address": "100 N NON EXISTENT ST",
+    "note": "no violation record found for this address.",
+    "start_date": "2020-01-01"
+  }
+]

--- a/tests/test_inspections.py
+++ b/tests/test_inspections.py
@@ -1,7 +1,125 @@
 import pytest
 from apt_app.views.fetch_inspections import parse_address, _fetch_inspection_summaries
+from django.http import JsonResponse
+import json
+
+# available = addresses exist and have summaries (for non-trivial violations)
+available_addresses = ["5514 S BLACKSTONE AVE", "1401 E 55TH ST"]
 
 
-def test_address_parsing():
-    assert parse_address("6128 S KIMBARK AVE, CHICAGO, IL, 60637") == "6128 S KIMBARK AVE"
-    assert parse_address("6128 S KIMBARK AVE") == "6128 S KIMBARK AVE"
+# ref: https://docs.pytest.org/en/stable/how-to/fixtures.html#parametrizing-fixtures
+@pytest.fixture(params=available_addresses)
+def available_response(request, db) -> JsonResponse:
+    return _fetch_inspection_summaries(request.param)
+
+
+def test_available_response_format(available_response):
+    """
+    Test that the response is in the correct format
+    """
+    expected_keys = {
+        "data_status",
+        "summary",
+        "note",
+        "total_violations_count",
+        "total_inspections_count",
+        "start_date",
+        "summarized_issues",
+        "start_date",
+    }
+    assert available_response.status_code == 200, (
+        f"Response status code: {available_response.status_code} is not 200"
+    )
+    response_content = json.loads(available_response.content)
+    assert response_content["data_status"] == "available", (
+        f"Response status: {response_content['data_status']} is not 'available'"
+    )
+    # Check if all expected keys appear in the response
+    response_keys = set(response_content.keys())
+    assert expected_keys <= response_keys, (
+        f"Expected keys {expected_keys - response_keys} are missing in the response"
+    )
+
+    # Check if 'summarized_issues' is a list and contains expected structure
+    assert isinstance(response_content.get("summarized_issues"), list)
+    for occasion in response_content.get("summarized_issues", []):
+        assert "date" in occasion, f"Occasion {occasion} does not have a 'date' key"
+        assert "issues" in occasion, f"Occasion {occasion} does not have an 'issues' key"
+        issues = occasion["issues"]
+        assert isinstance(issues, list), f"Occasion {occasion} has a non-list 'issues' key"
+        for issue in issues:
+            assert "emoji" in issue, (
+                f"Occasion {occasion} has an issue {issue} that does not have an 'emoji' key"
+            )
+            assert "description" in issue, (
+                f"Occasion {occasion} has an issue {issue} that does not have a 'description' key"
+            )
+
+
+trivial_only_addresses = ["1451 E 55TH ST"]
+
+
+@pytest.fixture(params=trivial_only_addresses)
+def trivial_only_response(request, db) -> JsonResponse:
+    return _fetch_inspection_summaries(request.param)
+
+
+def test_trivial_only_response_format(trivial_only_response):
+    """
+    Test that the response is in the correct format
+    """
+    assert trivial_only_response.status_code == 200, (
+        f"Response status code: {trivial_only_response.status_code} is not 200"
+    )
+    response_content = json.loads(trivial_only_response.content)
+    assert response_content["data_status"] == "trivial_only", (
+        f"Response status: {response_content['data_status']} is not 'trivial_only'"
+    )
+
+    expected_keys = {
+        "data_status",
+        "note",
+        "total_violations_count",
+        "total_inspections_count",
+        "start_date",
+    }
+    response_keys = set(response_content.keys())
+    assert expected_keys <= response_keys, (
+        f"Expected keys {expected_keys - response_keys} are missing in the response"
+    )
+
+
+no_violations_addresses = ["100 N NON EXISTENT ST"]
+
+
+@pytest.fixture(params=no_violations_addresses)
+def no_violations_response(request, db) -> JsonResponse:
+    return _fetch_inspection_summaries(request.param)
+
+
+def test_no_violations_response_format(no_violations_response):
+    """
+    Test that the response is in the correct format
+    """
+    assert no_violations_response.status_code == 200, (
+        f"Response status code: {no_violations_response.status_code} is not 200"
+    )
+    response_content = json.loads(no_violations_response.content)
+    assert response_content["data_status"] == "no_violations", (
+        f"Response status: {response_content['data_status']} is not 'no_violations'"
+    )
+
+    expected_keys = {"data_status", "note", "start_date"}
+    response_keys = set(response_content.keys())
+    assert expected_keys <= response_keys, (
+        f"Expected keys {expected_keys - response_keys} are missing in the response"
+    )
+
+
+@pytest.mark.django_db
+def test_endpoint_available(client):
+    """
+    Test that the endpoint is available
+    """
+    response = client.get("/fetch_inspections/", {"address": "5514 S BLACKSTONE AVE"})
+    assert response.status_code == 200, f"Response status code: {response.status_code} is not 200"


### PR DESCRIPTION
This is a PR that integrates updates made in response to both #93 and #83 . the JSON return of the endpoint is now updated with a new field `data_status` that cues the front-end team about variations in the return structure depending on data availability. For more details, see #93. As a result, all the tests that were initially written for #83 are also updated to support the augmented return structure. 