### PR TITLE
Add address saving into JS for save/delete endpoints

### DIFF
--- a/static/js/address_submission.js
+++ b/static/js/address_submission.js
@@ -163,9 +163,9 @@ function updateSearchView(data) {
   */
   // First, extract address parts from the `fetch_all_data` reponse
   address_parts = data["cleaned_address"].split(/,(.*)/s); // Ref: https://stackoverflow.com/a/4607799
-  console.log(address_parts);
   
   const title = document.getElementById("search-box-title");
+  title.dataset.address = data["cleaned_address"];
   title.innerText = toTitleCase(address_parts[0]);
   title.classList.remove("is-skeleton");
 


### PR DESCRIPTION
@arkadeep This adds the address information you requested into the data attribute of the title tag after the `fetch_all_data` request.

It can be accessed as follows:
![image](https://github.com/user-attachments/assets/e5df7a83-fc06-4d1c-be7c-01befa283b3a)

If there's anything else you would like added to the title tag, please let me know and I can make a modification prior to merging this in.