### PR TITLE
Standardize marker colors, map login screens and UChicago marker

### DIFF
--- a/static/js/address_submission.js
+++ b/static/js/address_submission.js
@@ -130,14 +130,17 @@ async function sendRequest(endpoint, body) {
   return fetch(url, { method: 'GET' });
 }
 
-async function parse_busroutes(data) {
+export async function parse_busroutes(data, dist=15) {
   /** Takes the fetch_routes output and produces a list of unique routes.
    *  @param {Object} data - a JSON formatted list of responses.
+   *  @param {int} dist - the distance to parse routes from 
    *  @returns {array} routes - a list of unique bus routes to request 
   */
   let routes = []; 
   for (const elem of data.bus_stops_geojson.features) {
-    routes = routes.concat(elem.properties.routes); // ['171', '55']
+    if (elem.properties.distance_min <= dist) {
+      routes = routes.concat(elem.properties.routes); // ['171', '55']
+    }
   } 
   return [...new Set(routes)]; // ref: https://stackoverflow.com/a/9229821
 }

--- a/static/js/init_map.js
+++ b/static/js/init_map.js
@@ -1,0 +1,37 @@
+// Import the shared map state object
+import { mapState } from './map_state.js';
+
+/**
+ * Initializes a static MapLibre map for the login screens.
+ *
+ * This script checks for a DOM element with id="map" and ensures
+ * the map is only initialized once using the shared `mapState` object.
+ *
+ * The map is non-interactive and centered on the University of Chicago.
+ * Intended for use on basic login screens.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  // Check if there is an element with id="map" on the page
+  const mapContainer = document.getElementById('map');
+
+  // If no map container exists, skip map initialization
+  if (!mapContainer) {
+    return;
+  }
+
+  // Prevent duplicate initialization if the map already exists (e.g., in home.html)
+  if (mapState.map) {
+    return;
+  }
+
+  // Initialize MapLibre map (STATIC at first)
+  mapState.map = new maplibregl.Map({
+    container: 'map',
+    style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
+    center: [-87.5995, 41.7925], 
+    zoom: 13.6,
+    interactive: false 
+  });
+
+});
+

--- a/static/js/map_modifications.js
+++ b/static/js/map_modifications.js
@@ -90,7 +90,7 @@ function resetButtons() {
   if (busRoutesBtn) busRoutesBtn.classList.remove('is-warning');
 }
 
-function getDistanceFilter() {
+export function getDistanceFilter() {
   let filterSelect = document.getElementById("distanceFilter");
   return filterSelect ? parseInt(filterSelect.value) : 5;
 }
@@ -287,7 +287,3 @@ function markUChicago() {
     // Ensure the popup is visible immediately  
     popup.addTo(mapState.map);  
 }
-
-
-
-

--- a/static/js/map_modifications.js
+++ b/static/js/map_modifications.js
@@ -38,13 +38,16 @@ export async function placeAddress(response) {
   // Move to the address
   map.flyTo({
     center: [lon, lat],
-    zoom: 15
+    zoom: 14
   });
 
   // Add marker
-  currentMarker = new maplibregl.Marker({ color: 'yellow' })
+  currentMarker = new maplibregl.Marker({ color: 'tomato' })
     .setLngLat([lon, lat])
     .addTo(map);
+
+    // Add a fixed maroon marker with popup for University of Chicago
+    markUChicago();
 }
 
 function enableMapInteraction() {
@@ -82,9 +85,9 @@ function resetButtons() {
   const groceriesBtn = document.getElementById('groceriesButton');
   const busStopsBtn = document.getElementById('busStopsButton');
   const busRoutesBtn = document.getElementById('busRoutesButton');
-  if (groceriesBtn) groceriesBtn.classList.remove('is-info');
+  if (groceriesBtn) groceriesBtn.classList.remove('is-success');
   if (busStopsBtn) busStopsBtn.classList.remove('is-info');
-  if (busRoutesBtn) busRoutesBtn.classList.remove('is-info');
+  if (busRoutesBtn) busRoutesBtn.classList.remove('is-warning');
 }
 
 function getDistanceFilter() {
@@ -133,7 +136,7 @@ export function updateGroceries() {
   groceryMarkers = loadMarkersToMap(
     mapState.groceryData.grocery_geojson,
     distanceMin,
-    'green',
+    'seagreen',
     props => `<strong>${props.name}</strong><br>${props.address}`
   );
 }
@@ -144,7 +147,7 @@ export function updateBusStops() {
   busStopMarkers = loadMarkersToMap(
     mapState.busStopData.bus_stops_geojson,
     distanceMin,
-    'blue',
+    'deepskyblue',
     props => `<strong>${props.stop_name}</strong><br>Routes: ${props.routes.join(", ")}`
   );
 }
@@ -152,7 +155,7 @@ export function updateBusStops() {
 export function toggleGroceries() {
   const groceriesBtn = document.getElementById('groceriesButton');
   mapState.groceriesOn = !mapState.groceriesOn;
-  groceriesBtn.classList.toggle('is-info', mapState.groceriesOn);
+  groceriesBtn.classList.toggle('is-success', mapState.groceriesOn);
   if (mapState.groceriesOn) {
     console.log("Groceries button turned ON");
     updateGroceries();
@@ -259,3 +262,32 @@ export function toggleBusRoute(map, geojsonFeature) {
       displayBusRoute(map, geojsonFeature);
   }
 }
+
+/**
+ * Marks the University of Chicago on the map with a maroon pin
+ * and displays a fixed popup showing the name.
+ */
+function markUChicago() {
+  const uchicagoCoords = [-87.5997, 41.7897]; 
+
+  // Create a fixed popup with the name "University of Chicago"
+  const popup = new maplibregl.Popup({
+    closeButton: false,
+    closeOnClick: false,
+    offset: 40   
+  })
+    .setText("University of Chicago");
+
+    // Add a maroon pin at UChicago coordinates and attach the popup
+    new maplibregl.Marker({ color: '#800000' })  
+    .setLngLat(uchicagoCoords)
+    .setPopup(popup)
+    .addTo(mapState.map);
+
+    // Ensure the popup is visible immediately  
+    popup.addTo(mapState.map);  
+}
+
+
+
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,9 @@
       });
     </script>
 
+  <!-- Initialize map if #map is present -->
+  <script type="module" src="{% static 'js/init_map.js' %}"></script>
+
   </body>
 
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -157,8 +157,8 @@
 <script src="{% static 'js/utils.js' %}"></script>
 <script type="module">
   import { mapState } from '{% static "js/map_state.js" %}';
-  import { getApartment } from '{% static "js/address_submission.js" %}';
-  import { updateBusStops, updateGroceries, toggleBusStops, toggleGroceries, toggleBusRoute, displayBusRoute, clearBusRoutes } from '{% static "js/map_modifications.js" %}';
+  import { getApartment, parse_busroutes } from '{% static "js/address_submission.js" %}';
+  import { updateBusStops, updateGroceries, toggleBusStops, toggleGroceries, toggleBusRoute, displayBusRoute, clearBusRoutes, getDistanceFilter } from '{% static "js/map_modifications.js" %}';
 
   // Initialize MapLibre map (STATIC at first)
   mapState.map = new maplibregl.Map({
@@ -188,19 +188,23 @@
     }
 
     if (busRoutesBtn) {
-      mapState.busRoutesOn = !mapState.busRoutesOn;
-      busRoutesBtn.classList.toggle('is-info', mapState.busRoutesOn);
+      const filterSelect = getDistanceFilter();
+      console.log(mapState);
+      parse_busroutes(mapState.busStopData, filterSelect).then(closeRoutes => {
+        // Manage button
+        mapState.busRoutesOn = !mapState.busRoutesOn;
+        busRoutesBtn.classList.toggle('is-info', mapState.busRoutesOn);
 
-      if (mapState.busRoutesOn) {
-      // Turn ON/OFF all routes (for now)
-        for (const busRoute of mapState.busRoutesData.features) {
-          // console.log(`Plotting: ${busRoute.properties.route_id}`)
-          // console.log(busRoute)
-          displayBusRoute(mapState.map, busRoute);
+        if (mapState.busRoutesOn) {
+          for (const busRoute of mapState.busRoutesData.features) {
+            if (closeRoutes.includes(busRoute.properties.route_id)) {
+              displayBusRoute(mapState.map, busRoute);
+            }
+          }
+        } else {
+          clearBusRoutes(mapState.map);
         }
-      } else {
-          clearBusRoutes(mapState.map)
-        }
+      });
     }
   });
 


### PR DESCRIPTION
Hi @m-rosenbaum 
This PR includes two small updates:

1. Standardizing Marker Colors
I made a light-touch change to align marker colors with button styles.

Instead of modifying map logic, I adjusted the Bulma button classes and then chose a matching color for the markers using MapLibre's color settings.

I did not update the marker color in busroutes.js, since the logic there is a bit more involved.

and add a Marker with a fixed popup for UChicago. 

2. Static Map Initialization on Login Screens
Added a check to ensure the map is only initialized on login screens if the #map container is present and no map has been previously created.

The change is scoped to login pages for now, but it could easily be extended to the home.html

Let me know if anything should be adjusted. Thanks!