### PR TITLE
chore(comparison): temporarily remove 'Show on Map' button

### DIFF
--- a/templates/saved_properties.html
+++ b/templates/saved_properties.html
@@ -109,12 +109,13 @@
 
                     <!-- Card footer with actions -->
                     <footer class="card-footer">
+                        <!-- Temporarily disabled                        
                         <a href="/?address={{ saved_property.address|urlencode }}" class="card-footer-item">
                             <span class="icon-text">
                                 <span class="icon"><i class="fas fa-map"></i></span>
                                 <span>View on Map</span>
                             </span>
-                        </a>
+                        </a> -->
                         <button class="card-footer-item button is-white has-text-danger" hx-post="/delete_property/"
                             hx-vals='{"property_address": "{{ saved_property.address }}", "source": "saved_properties"}'
                             hx-target="#property-card-{{ forloop.counter }}" hx-swap="innerHTML fade-out"


### PR DESCRIPTION
Temporarily removing the Show on Map button from the comparison screen. Felt that it would be best to remove this button since I wasn't able to hook it up with the desired redirect functionality. 