### PR TITLE
chore: add auto-restart option to docker web

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -263,6 +263,14 @@ services:
       - postgres
     env_file:
       - .env
+# Commenting out healthcheck below until we can get more robust monitoring up.
+#    healthcheck:
+#      test: ["CMD", "curl", "--fail", "http://localhost:9000/about"]
+#      interval: 1m
+#      timeout: 10s
+#      start_period: 30s
+#      retries: 3
+    restart: always
 
 volumes:
   postgres-db-volume:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -263,14 +263,16 @@ services:
       - postgres
     env_file:
       - .env
-# Commenting out healthcheck below until we can get more robust monitoring up.
-#    healthcheck:
-#      test: ["CMD", "curl", "--fail", "http://localhost:9000/about"]
-#      interval: 1m
-#      timeout: 10s
-#      start_period: 30s
-#      retries: 3
+    # Automatically restart on failure to ensure service availability
     restart: always
+
+    # Commenting out healthcheck below until we can get more robust monitoring up.
+    # healthcheck:
+    #   test: ["CMD", "curl", "--fail", "http://localhost:9000/about"]
+    #   interval: 1m
+    #   timeout: 10s
+    #   start_period: 30s
+    #   retries: 3
 
 volumes:
   postgres-db-volume:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -264,7 +264,7 @@ services:
     env_file:
       - .env
     # Automatically restart on failure to ensure service availability
-    restart: always
+    restart: unless-stopped
 
     # Commenting out healthcheck below until we can get more robust monitoring up.
     # healthcheck:


### PR DESCRIPTION
# What does this pull request do?
This pull request adds a [setting](https://github.com/compose-spec/compose-spec/blob/main/spec.md#restart) to the docker compose to restart the web image whenever it fails.

# Considerations
- I have not yet restarted the entire docker instance on the server. After reviewing this, could whoever merges it go into the server and update? I think this should just be a `git pull` and `docker-compose up -d --build`.
- It seems like [healthchecks are best practice](https://stackoverflow.com/questions/62212675/what-happens-to-a-docker-container-when-healthcheck-fails?noredirect=1&lq=1) for monitoring when instances fail, and allow you to have a bash script (or Docker Swarm) to restart them. As we move towards a more robust monitoring system, I think it would be more relevant. However, I don't see a need to include it now. I've left in the commented out code when I initially thought this would be an approach to have Docker handle it.